### PR TITLE
[Fix] #10773 Solve issues with Conan package manager

### DIFF
--- a/.github/workflows/check-licenses.yml
+++ b/.github/workflows/check-licenses.yml
@@ -31,9 +31,9 @@ jobs:
       - name: Clone License Check Repo
         uses: actions/checkout@v3
         with:
-          repository: eclipse-velocitas/license-check
+          repository: softwaredefinedvehicle/license-check
+          ref: fix/conan_issues
           path: .github/actions/license-check
-          ref: main
 
       - name: Run License Checker
         id: checker

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,5 +40,7 @@ ENV CONAN_USER_HOME=/root
 ENV CARGO_HOME=/root/.cargo
 ENV RUSTUP_HOME=/root/.rustup
 
+COPY ./patches/ /
+
 # Run the Python3 Github Action wrapper
 ENTRYPOINT ["python3", "-u", "/action.py"]

--- a/patches/var/lib/gems/2.7.0/gems/license_finder-7.0.1/lib/license_finder/package_managers/conan.rb
+++ b/patches/var/lib/gems/2.7.0/gems/license_finder-7.0.1/lib/license_finder/package_managers/conan.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'license_finder/package_utils/conan_info_parser'
+
+module LicenseFinder
+  class Conan < PackageManager
+    def possible_package_paths
+      [project_path.join('conanfile.py'), project_path.join('conanfile.txt')]
+    end
+
+    def current_packages
+      install_command = 'conan install .'
+      info_command = 'conan info .'
+      Dir.chdir(project_path) { Cmd.run(install_command) }
+      info_output, _stderr, _status = Dir.chdir(project_path) { Cmd.run(info_command) }
+
+      info_parser = ConanInfoParser.new
+
+      deps = info_parser.parse(info_output)
+      deps.map do |dep|
+        name, version = dep['name'].split('/')
+        url = dep['URL']
+        license_file_path = Dir.glob("#{project_path}/licenses/#{name}/**/LICENSE*").first
+        ConanPackage.new(name, version, license_file_path ? File.open(license_file_path).read : "", url) unless name.start_with?("conanfile.py", "conanfile.txt")
+      end.compact
+    end
+  end
+end

--- a/patches/var/lib/gems/2.7.0/gems/license_finder-7.0.1/lib/license_finder/package_managers/conan.rb
+++ b/patches/var/lib/gems/2.7.0/gems/license_finder-7.0.1/lib/license_finder/package_managers/conan.rb
@@ -11,7 +11,13 @@ module LicenseFinder
     def current_packages
       install_command = 'conan install .'
       info_command = 'conan info .'
-      Dir.chdir(project_path) { Cmd.run(install_command) }
+      _stdout, _stderr, _status = Dir.chdir(project_path) { Cmd.run(install_command) }
+      if not _status.success?
+        logger.info self.class, "Error while running 'conan install':"
+        logger.debug self.class, "#{_stdout}"
+        logger.debug self.class, "#{_stderr}"
+        logger.info self.class, "Most/all packages will be rated having an unknown license!"
+      end
       info_output, _stderr, _status = Dir.chdir(project_path) { Cmd.run(info_command) }
 
       info_parser = ConanInfoParser.new

--- a/src/dependency_decisions_overwrites.yml
+++ b/src/dependency_decisions_overwrites.yml
@@ -14,6 +14,13 @@
 
 ---
 - - :license
+  - libcurl
+  - CURL
+  - :who: BjoernAtBosch (Bjoern.Hornburg@de.bosch.com)
+    :why: https://curl.se/docs/copyright.html
+    :versions: []
+    :when: 2022-08-30 16:12:04.826121174 Z
+- - :license
   - protobuf
   - Google License
   - :who: Google Inc

--- a/src/licensevalidator/lib/workflowlicenses.py
+++ b/src/licensevalidator/lib/workflowlicenses.py
@@ -163,10 +163,11 @@ def __get_license_for_action(action_repo: str) -> Optional[str]:
     )
     try:
         return result.json()["license"]["name"]
-    except ValueError as err:
-        print(err)
-        print(action_repo)
-        print(result.json())
+    except (KeyError, ValueError) as err:
+        print("Error getting workflow license info from github.com:")
+        print(f"   {err}")
+        print(f"   {action_repo}")
+        print(f"   {result.json()}")
 
     return None
 


### PR DESCRIPTION
Issues:
* Pivotal License Finder cannot handle Conan requirements given as `conanfile.py` (just `conanfile.txt`)
* Pivotal License Finder crashes if Conan packages don't provide a `LICENSE*` file (e.g. libcurl)
* Pivotal License Finder crashes if `conan install` fails
* The GitHub Workflow scanner crashes, if license information about a workflow cannot be gathered from github.com

Solution:
* Fix Pivotal License Finder by adding a patch handling `conanfile.py`
* Set license to "unknown" if `conan install` fails or no `LICENSE*` file is found
* Set license info for libcurl manually
* Fix Workflow scanner by error handling