### PR TITLE
add curations for current grpcio version

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+# Copyright (c) 2022-2023 Robert Bosch GmbH and Microsoft Corporation
 #
 # This program and the accompanying materials are made available under the
 # terms of the Apache License, Version 2.0 which is available at

--- a/.ort.yml
+++ b/.ort.yml
@@ -20,9 +20,13 @@ curations:
     curations:
       comment: "Add correct license"
       concluded_license: BSD-3-Clause
-  - id: "PyPI::grpcio:1.49.1"
+  - id: "PyPI::grpcio:1.51.1"
     curations:
       comment: "Add correct license"
+      concluded_license: Apache-2.0
+  - id: "PyPI::grpcio:1.52.0"
+    curations:
+      comment: "Add correct license. Although this is a yanked version, ORT somehow uses it."
       concluded_license: Apache-2.0
 
 resolutions:

--- a/.ort.yml
+++ b/.ort.yml
@@ -1,3 +1,17 @@
+# Copyright (c) 2022 Robert Bosch GmbH and Microsoft Corporation
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
 curations:
   packages:
   - id: "Conan::openssl:1.1.1n"


### PR DESCRIPTION
Update curations for grpcio.

1.51.1 should be used. Somehow the ORT installs the yanked version 1.52.0. To not do this again tomorrow, I added both versions.