### PR TITLE
Add proper tagging strategy for license checker

### DIFF
--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,13 +1,30 @@
-name: Create and Update Tags
+# Copyright (c) 2023 Robert Bosch GmbH
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License, Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0.
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Create/update tag
 on:
   workflow_dispatch:
-
+  push:
+    tags:
+      - 'v[0-9]+\.[0-9]+\.[0-9]+'
 jobs:
   create-tag:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - id: getVersions
+      - name: Get version from setup.py
+        id: getVersions
         run: |
           semantic_version=$(python setup.py --version)
           major_version=$(cut -d '.' -f 1 <<< "$semantic_version")
@@ -16,7 +33,21 @@ jobs:
           echo "major_version=v$major_version" >> $GITHUB_OUTPUT
           echo "major_minor_version=v$major_minor_version" >> $GITHUB_OUTPUT
 
-      - uses: rickstaa/action-create-tag@v1
+      - name: Check manual created tag
+        id: manualTag
+        if: github.ref_type == 'tag'
+        run: |
+          if [ "${GITHUB_REF#refs/*/}" != ${{ steps.getVersions.outputs.semantic_version }} ]; then
+            echo "Please align desired tag: '${GITHUB_REF#refs/*/}' ${{ github.ref }} with setup.py version '${{ steps.getVersions.outputs.semantic_version }}'"
+            echo "Deleting manual created tag"
+            git push --delete origin ${GITHUB_REF#refs/*/}
+            exit 1
+          else
+            echo "All fine"
+          fi
+
+      - name: Create full version tag - ${{ steps.getVersions.outputs.semantic_version }}
+        uses: rickstaa/action-create-tag@v1
         id: "tag_create_full_version"
         with:
           tag: ${{ steps.getVersions.outputs.semantic_version }}
@@ -24,7 +55,8 @@ jobs:
           force_push_tag: false
           message: "${{ steps.getVersions.outputs.semantic_version }}"
 
-      - uses: rickstaa/action-create-tag@v1
+      - name: Create major.minor version tag - ${{ steps.getVersions.outputs.major_minor_version }}
+        uses: rickstaa/action-create-tag@v1
         id: "tag_create_major_minor"
         with:
           tag: ${{ steps.getVersions.outputs.major_minor_version }}
@@ -32,7 +64,8 @@ jobs:
           force_push_tag: true
           message: "${{ steps.getVersions.outputs.major_minor_version }}"
 
-      - uses: rickstaa/action-create-tag@v1
+      - name: Create major version tag - ${{ steps.getVersions.outputs.major_version }}
+        uses: rickstaa/action-create-tag@v1
         id: "tag_create_major"
         with:
           tag: ${{ steps.getVersions.outputs.major_version }}

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -1,0 +1,41 @@
+name: Create and Update Tags
+on:
+  workflow_dispatch:
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - id: getVersions
+        run: |
+          semantic_version=$(python setup.py --version)
+          major_version=$(cut -d '.' -f 1 <<< "$semantic_version")
+          major_minor_version=$(cut -d '.' -f 1,2 <<< "$semantic_version")
+          echo "semantic_version=v$semantic_version" >> $GITHUB_OUTPUT
+          echo "major_version=v$major_version" >> $GITHUB_OUTPUT
+          echo "major_minor_version=v$major_minor_version" >> $GITHUB_OUTPUT
+
+      - uses: rickstaa/action-create-tag@v1
+        id: "tag_create_full_version"
+        with:
+          tag: ${{ steps.getVersions.outputs.semantic_version }}
+          tag_exists_error: true
+          force_push_tag: false
+          message: "${{ steps.getVersions.outputs.semantic_version }}"
+
+      - uses: rickstaa/action-create-tag@v1
+        id: "tag_create_major_minor"
+        with:
+          tag: ${{ steps.getVersions.outputs.major_minor_version }}
+          tag_exists_error: false
+          force_push_tag: true
+          message: "${{ steps.getVersions.outputs.major_minor_version }}"
+
+      - uses: rickstaa/action-create-tag@v1
+        id: "tag_create_major"
+        with:
+          tag: ${{ steps.getVersions.outputs.major_version }}
+          tag_exists_error: false
+          force_push_tag: true
+          message: "${{ steps.getVersions.outputs.major_version }}"

--- a/NOTICE-3RD-PARTY-CONTENT.md
+++ b/NOTICE-3RD-PARTY-CONTENT.md
@@ -3,13 +3,13 @@
 ## Python
 | Dependency | Version | License |
 |:-----------|:-------:|--------:|
-|certifi|2022.12.7|Mozilla Public License 2.0|
+|certifi|2023.5.7|Mozilla Public License 2.0|
 |charset-normalizer|3.1.0|MIT|
 |gitdb|4.0.10|BSD|
 |GitPython|3.1.31|BSD|
 |idna|3.4|BSD|
 |PyYAML|6.0|MIT|
-|requests|2.29.0|Apache 2.0|
+|requests|2.30.0|Apache 2.0|
 |smmap|5.0.0|BSD|
 |str2bool|1.1|BSD|
 |urllib3|1.26.15|MIT|
@@ -18,3 +18,4 @@
 |:-----------|:-------:|--------:|
 |actions/checkout|v3|MIT License|
 |github/codeql-action|v1|MIT License|
+|rickstaa/action-create-tag|v1|MIT License|


### PR DESCRIPTION
This PR adds a workflow for manual execution (could also be done automatically if preferred).
The workflow creates and/or update tags based on the version of the setup.py of the license checker.

It will look like the following:
setup.py version = 1.2.3

tags are created for:

v1 -> commit hash "aaa"
v1.2 -> commit hash "aaa"
v1.2.3 -> commit hash "aaa"

if the next tag should be created based on the setup.py version = 1.3.0

tags are either updated or maintain like before:

v1 -> commit hash updates to "bbb"
v1.2 -> commit hash stays at "aaa"
v1.2.3 -> commit hash stays at "aaa"
v1.3 -> is created and points to "bbb"
v1.3.0 -> is created and points to "bbb"

if the next tag should be created based on the setup.py version = 2.0.0

tags are either updated or maintain like before:

v1 -> commit hash stays at "bbb"
v1.2 -> commit hash stays at "aaa"
v1.2.3 -> commit hash stays at "aaa"
v1.3 -> commit hash stays at "bbb"
v1.3.0 -> commit hash stays at "bbb"
v2 -> is created and points to "ccc"
v2.0 -> is created and points to "ccc"
v2.0.0 -> is created and points to "ccc"

The advantage of having this tagging strategy is to use the github checkout action pointing to just one version ref:

```
      - name: Clone License Check Repo
        uses: actions/checkout@v3
        with:
          repository: eclipse-velocitas/license-check
          path: .github/actions/license-check
          ref: v1
```

when running this action like that it will use the license checker based on the commit hash of the tag v1(.x.x)